### PR TITLE
Fix error generation bug.

### DIFF
--- a/client.go
+++ b/client.go
@@ -52,25 +52,23 @@ func StartClient(url_, heads, meth string, dka bool, responseChan chan *Response
 		tr = &http.Transport{DisableKeepAlives: dka}
 	}
 
-	req, _ := http.NewRequest(meth, url_, nil)
-	sets := strings.Split(heads, "\n")
-
-	//Split incoming header string by \n and build header pairs
-	for i := range sets {
-		split := strings.SplitN(sets[i], ":", 2)
-		if len(split) == 2 {
-			req.Header.Set(split[0], split[1])
-		}
-	}
-
 	timer := NewTimer()
 	for {
+		req, _ := http.NewRequest(meth, url_, nil)
+
+		//Split incoming header string by \n and build header pairs
+		sets := strings.Split(heads, "\n")
+		for i := range sets {
+			split := strings.SplitN(sets[i], ":", 2)
+			if len(split) == 2 {
+				req.Header.Set(split[0], split[1])
+			}
+		}
+
 		timer.Reset()
 
-		resp, err := tr.RoundTrip(req)
-
 		respObj := &Response{}
-
+		resp, err := tr.RoundTrip(req)
 		if err != nil {
 			respObj.Error = true
 		} else {


### PR DESCRIPTION
I had an issue in relation to this one ( #12 ) and I think I may have found the cause. Turns out having the request created prior to the for loop where tr.RoundTrip is called is forcing the connection to cancel (see line 1402 of https://golang.org/src/net/http/transport.go where pc.t.replaceReqCanceler is called, and subsequently it's function definition on line 642). The comments on replaceReqCanceler says:
```go
// replaceReqCanceler replaces an existing cancel function. If there is no cancel function
// for the request, we don't set the function and return false.
// Since CancelRequest will clear the canceler, we can use the return value to detect if
// the request was canceled since the last setReqCancel call.
```
That means that the request outside of the loop is in turn getting canceled due to replaceReqCanceler function call that is with in *transport.RoundTrip returning false if I understand this correctly.

Creating a new request per RoundTrip seems to solve this error generation. So I moved the request preparation inside the loop. Is this okay? Would love help with making sure I'm looking in the right direction.

EDIT:
Disregard for now, I think I'm going on the wrong path here. Quite confused.