### PR TITLE
Create a new request with a new reader for each iteration

### DIFF
--- a/client.go
+++ b/client.go
@@ -52,21 +52,20 @@ func StartClient(url_, heads, requestBody string, meth string, dka bool, respons
 		tr = &http.Transport{DisableKeepAlives: dka}
 	}
 
-	requestBodyReader := strings.NewReader(requestBody)
-
-	req, _ := http.NewRequest(meth, url_, requestBodyReader)
-	sets := strings.Split(heads, "\n")
-
-	//Split incoming header string by \n and build header pairs
-	for i := range sets {
-		split := strings.SplitN(sets[i], ":", 2)
-		if len(split) == 2 {
-			req.Header.Set(split[0], split[1])
-		}
-	}
-
 	timer := NewTimer()
 	for {
+		requestBodyReader := strings.NewReader(requestBody)
+		req, _ := http.NewRequest(meth, url_, requestBodyReader)
+		sets := strings.Split(heads, "\n")
+
+		//Split incoming header string by \n and build header pairs
+		for i := range sets {
+			split := strings.SplitN(sets[i], ":", 2)
+			if len(split) == 2 {
+				req.Header.Set(split[0], split[1])
+			}
+		}
+
 		timer.Reset()
 
 		resp, err := tr.RoundTrip(req)


### PR DESCRIPTION
Move the request creation inside the for loop because of the requestBody reader. Once the body is readed, each subsequent request will return an error because the body is now empty. 
To test it, send 10 requests with a body and set the maximum number of connection to 1…you will get 9 errors.

`go-wrk -m "POST" -b ”myBody” -n 10 -t=8 -c=1 http://127.0.0.1:8000/test`

```
==========================BENCHMARK==========================
URL:				http://127.0.0.1:8000/test

Used Connections:		1
Used Threads:			8
Total number of calls:		10

===========================TIMINGS===========================
Total time passed:		0.00s
Avg time per request:		0.25ms
Requests per second:		3507.54
Median time per request:	0.20ms
99th percentile time:		0.15ms
Slowest time for request:	0.00ms

=============================DATA=============================
Total response body sizes:		0
Avg response body per request:		0.00ms
Transfer rate per second:		0.00 Byte/s (0.00 MByte/s)
==========================RESPONSES==========================
20X Responses:		1	(10.00%)
30X Responses:		0	(0.00%)
40X Responses:		0	(0.00%)
50X Responses:		0	(0.00%)
Errors:			9	(90.00%)
```